### PR TITLE
Updated to Groovy 4 to be used with Spring Boot 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
     id 'signing'
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.6
+sourceCompatibility = 11
+targetCompatibility = 11
 
 scmVersion {
     tag {
@@ -24,11 +24,11 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.3'
-    compile 'org.apache.httpcomponents:httpclient:4.4'
+    compile 'org.codehaus.groovy:groovy-all:4.0.11'
+    compile 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
-    testCompile 'com.github.tomakehurst:wiremock:1.54'
+    testCompile 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testCompile 'com.github.tomakehurst:wiremock:2.27.2'
     //for wiremock logging
     testCompile 'ch.qos.logback:logback-classic:1.1.3'
     testCompile 'ch.qos.logback:logback-core:1.1.3'


### PR DESCRIPTION
Migrated to Groovy 4 so this library can be sued with `Spring Boot 3`:
* Updated to Java `11`
* Updated Groovy to `4.0.11`
* Updated httpclient to `4.5.14`
* Updated spock core to `2.3-groovy-4.0`
* Updated wiremock to `2.27.2`